### PR TITLE
Add scripts to simplify deployment and run against local pgDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sls deploy -v
 ```
 ☕ Coffeetime:  AWS takes ~10min to setup the Postgres DB
 
-## Populate DB and set endpoints:
+### Populate DB and set endpoints:
 
 * From the result of `sls deploy` take the `pgEndpoint` and insert it in:
   * `package.json`-file in the config of `PGCON` (line 7)
@@ -32,7 +32,7 @@ The last command runs a SQL query to get schema-information about the Postgres D
 The information is written to a JSON-file which is then loaded by the lambda function (handler.js)
 to build the graphql-schema.
 
-## Deploy & Test
+### Deploy & Test
 
 Deploy to Server:
   * `sls deploy function -f graphql` or for a 'full' deployment `sls deploy`
@@ -59,6 +59,20 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoxLCJiIjoyLCJjI
 
 * Here you can find an [in-depth explainaition](https://github.com/calebmer/postgraphql/blob/master/examples/forum/TUTORIAL.md#authentication-and-authorization)
 * Gist on how to [query this endpoint in R](https://gist.github.com/rentrop/83cb1d8fc8593726a808032e55314019)
+
+## Running Locally
+
+💾 Install [Postgres](https://www.postgresql.org/) 🐘
+
+⌨️ Initialize the database
+```
+npm run init-local-db
+```
+
+⌨️ Run the local server
+```
+npm run local-server
+```
 
 # TODO/Ideas
 * Responde with error-codes.  

--- a/README.md
+++ b/README.md
@@ -7,35 +7,34 @@ and [postgraphql](https://github.com/calebmer/postgraphql)
 # How to use:
 
 ## Setup
-[Install serverless](https://github.com/serverless/serverless#quick-start)
+💾 Install [Serverless](https://github.com/serverless/serverless#quick-start)
 
+👯 Clone the repo
 ```
 git clone https://github.com/rentrop/serverless-postgraphql
 cd serverless-postgraphql
-npm install
-sls deploy -v
 ```
+
+💾 Install
+```
+npm install
+```
+
+🚀 Rebuild and Deploy
+```
+npm run rebuild-and-deploy
+```
+
 ☕ Coffeetime:  AWS takes ~10min to setup the Postgres DB
 
-### Populate DB and set endpoints:
-
-* From the result of `sls deploy` take the `pgEndpoint` and insert it in:
+* From the result of the serverless deployment take the `pgEndpoint` and insert it in:
   * `package.json`-file in the config of `PGCON` (line 7)
   * `serverless.yml`-file in the environment-variable named `PGCON` (line 21)
-* Populate the DB with the data from postgraphql's excelent [forum example](https://github.com/calebmer/postgraphql/tree/master/examples/forum). You need the `psql` cli. On Mac just follow the instructions [here](http://postgresapp.com/) to install it.
-  * `npm run populate-schema`
-  * `npm run populate-data`
-* Get the schema from the database and write it as a json file:
-  * `npm run build-schema`
 
-The last command runs a SQL query to get schema-information about the Postgres DB.
-The information is written to a JSON-file which is then loaded by the lambda function (handler.js)
-to build the graphql-schema.
-
-### Deploy & Test
-
-Deploy to Server:
-  * `sls deploy function -f graphql` or for a 'full' deployment `sls deploy`
+🚀 Rebuild and Deploy Again
+```
+npm run rebuild-and-deploy
+```
 
 You are all set now. You can now query the resulting endpoint as you wish via __POST__ and __GET__.
 

--- a/package.json
+++ b/package.json
@@ -4,15 +4,28 @@
   "description": "postgraphql test on serverless",
   "main": "handler.js",
   "config": {
-    "PGCON": "postgresql://example:serverless@pgEndpoint:5432/forumexample"
+    "PGCON": "postgresql://example:serverless@pgEndpoint:5432/forumexample",
+    "PGLOCALCON": "postgresql://postgres@localhost:5432/forumexample",
+    "PGLOCALRUNCON": "postgresql://forum_example_postgraphql@localhost:5432/forumexample",
+    "PGLOCALINITCON": "postgresql://postgres@localhost:5432/"
   },
   "scripts": {
+    "init-local-db": "psql $npm_package_config_PGLOCALINITCON -f ./populateDB/initLocal.sql",
+    "local-server": "yarn run local-drop-rebuild;yarn run postgraphql-local",
+    "rebuild-and-deploy": "yarn run drop-data;yarn run populate-schema;yarn run populate-data;yarn run build-schema;sls deploy -v",
+
     "test": "echo \"Error: no test specified\" && exit 1",
     "populate-schema": "psql $npm_package_config_PGCON -f ./populateDB/schema.sql",
     "populate-data": "psql $npm_package_config_PGCON -f ./populateDB/data.sql",
     "drop-data": "psql $npm_package_config_PGCON -f ./populateDB/drop.sql",
     "build-schema": "node ./pgCatalog/buildPgCatalog.js $npm_package_config_PGCON forum_example",
-    "postgraphql-local": "postgraphql --connection $npm_package_config_PGCON --schema forum_example --default-role forum_example_anonymous --secret keyboard_kitten --token forum_example.jwt_token"
+    "postgraphql-local-aws-db": "postgraphql --connection $npm_package_config_PGCON --schema forum_example --default-role forum_example_anonymous --secret keyboard_kitten --token forum_example.jwt_token",
+    "postgraphql-local": "postgraphql --connection $npm_package_config_PGLOCALRUNCON --schema forum_example --default-role forum_example_anonymous --secret keyboard_kitten --token forum_example.jwt_token",
+    "build-local-schema": "node ./pgCatalog/buildPgCatalog.js $npm_package_config_PGLOCALCON floods",
+    "populate-local-schema": "psql $npm_package_config_PGLOCALCON -f ./populateDB/schema.sql",
+    "drop-local-data": "psql $npm_package_config_PGLOCALCON -f ./populateDB/drop.sql",
+    "populate-local-data": "psql $npm_package_config_PGLOCALCON -f ./populateDB/data.sql",
+    "local-drop-rebuild": "yarn run drop-local-data;yarn run populate-local-schema;yarn run populate-local-data;yarn run build-local-schema;"
   },
   "author": "Richard",
   "license": "MIT",

--- a/populateDB/initLocal.sql
+++ b/populateDB/initLocal.sql
@@ -1,0 +1,2 @@
+drop database if exists forumexample;
+create database forumexample;


### PR DESCRIPTION
Rebuilding and deploying used to take multiple commands and became tedious when making schema changes. In order to speed up development I added a script to drop/rebuild/deploy with one command. I also added scripts to allow for running against a local Postgres instance, which decreases the amount of time needed to test schema changes drastically.